### PR TITLE
Fix ORA-02199: missing DATAFILE/TEMPFILE when creating a new tablespace

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -10,7 +10,7 @@ apt-get update
 # Prepare to install Oracle
 apt-get install -y libaio1 net-tools bc &&
 ln -s /usr/bin/awk /bin/awk &&
-mkdir /var/lock/subsys &&
+mkdir -p /var/lock/subsys &&
 mv /assets/chkconfig /sbin/chkconfig &&
 chmod 755 /sbin/chkconfig &&
 

--- a/startup.sh
+++ b/startup.sh
@@ -55,6 +55,7 @@ service oracle-xe start
 export ORACLE_HOME=/u01/app/oracle/product/11.2.0/xe
 export PATH=$ORACLE_HOME/bin:$PATH
 export ORACLE_SID=XE
+export ORACLE_DATA=/u01/app/oracle/oradata/$ORACLE_SID
 
 
 if [ ! -e "/u01/app/oracle/initialized.id" ] ; then
@@ -77,6 +78,12 @@ if [ ! -e "/u01/app/oracle/initialized.id" ] ; then
 		echo "ALTER USER SYS PROFILE NOEXPIRY;" | sqlplus -s SYSTEM/oracle
 		echo "Security relaxed."
 		
+	fi
+
+	echo "Setting db_create_file_dest param..."
+	if ! echo "ALTER SYSTEM SET db_create_file_dest = '$ORACLE_DATA';" | sqlplus - s SYSTEM/oracle; then
+		echo "error setting db_create_file_dest param"
+		exit 1
 	fi
 
 	if [ -z "$ORACLE_PASSWORD" ] ; then

--- a/startup.sh
+++ b/startup.sh
@@ -81,7 +81,7 @@ if [ ! -e "/u01/app/oracle/initialized.id" ] ; then
 	fi
 
 	echo "Setting db_create_file_dest param..."
-	if ! echo "ALTER SYSTEM SET db_create_file_dest = '$ORACLE_DATA';" | sqlplus - s SYSTEM/oracle; then
+	if ! echo "ALTER SYSTEM SET db_create_file_dest = '$ORACLE_DATA';" | sqlplus -s SYSTEM/oracle; then
 		echo "error setting db_create_file_dest param"
 		exit 1
 	fi


### PR DESCRIPTION
Configured the db_create_file_dest as /u01/app/oracle/oradata/$ORACLE_SID.

Making the creation of new tablespaces possible.